### PR TITLE
🔨 Fix URL decoding and refine group message broadcasting 🔨

### DIFF
--- a/Dungeon_Dashboard/Services/NotesHub.cs
+++ b/Dungeon_Dashboard/Services/NotesHub.cs
@@ -40,6 +40,8 @@ namespace Dungeon_Dashboard.Hubs {
         }
 
         public async Task EditNotePatch(int roomId, int noteId, string patchText) {
+            patchText = Uri.UnescapeDataString(patchText);
+
             var note = await _db.NoteModel.FindAsync(noteId);
             if(note == null || note.RoomId != roomId)
                 return;
@@ -50,7 +52,7 @@ namespace Dungeon_Dashboard.Hubs {
             note.Timestamp = DateTime.UtcNow;
             await _db.SaveChangesAsync();
 
-            await Clients.Group(roomId.ToString())
+            await Clients.OthersInGroup(roomId.ToString())
                          .SendAsync("ReceiveNotePatch", noteId, patchText);
         }
 


### PR DESCRIPTION
🔐 Decoded the patchText parameter using Uri.UnescapeDataString to properly handle URL-encoded input 🔄 
🚫 Updated EditNotePatch to broadcast "ReceiveNotePatch" only to other clients in the same group, excluding the sender, by replacing Clients.Group with Clients.OthersInGroup 🎉 xd